### PR TITLE
🧹 Quick Wins: Remove duplicate import, pin base image

### DIFF
--- a/agent-image/Dockerfile
+++ b/agent-image/Dockerfile
@@ -1,7 +1,9 @@
 # Multi-language Claude Agent Image
 # Provides an isolated environment with Claude Code in YOLO mode
 
-FROM ubuntu:24.04
+# Pin to specific digest for reproducible builds
+# To update: docker pull ubuntu:24.04 && docker inspect ubuntu:24.04 --format='{{index .RepoDigests 0}}'
+FROM ubuntu:24.04@sha256:7a398144c5a2fa7dbd9362e460779dc6659bd9b19df50f724250c62ca7812eb3
 
 # Avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive

--- a/src/index.ts
+++ b/src/index.ts
@@ -507,7 +507,6 @@ async function spawnDockerAgent(args: {
 
   try {
     // Verify workspace path exists
-    const fs = await import("fs/promises");
     const stats = await fs.stat(workspace_path);
     if (!stats.isDirectory()) {
       throw new Error(`Workspace path is not a directory: ${workspace_path}`);


### PR DESCRIPTION
## Summary
- Remove redundant fs import in spawnDockerAgent
- Pin ubuntu:24.04 to specific digest for reproducibility

## Issues Fixed
- Closes #15 - Duplicate fs import
- Closes #12 - Container image version pinning

## Test Plan
- [ ] Verify TypeScript compiles without errors
- [ ] Check Docker build still works with pinned image

🤖 Generated with [Claude Code](https://claude.ai/claude-code) + Pinocchio