### PR TITLE
✨ Add ws dependency and expose WebSocket port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
       context: .
       dockerfile: Dockerfile
     image: pinocchio:latest
+    ports:
+      - "3001:3001"  # WebSocket server
     depends_on:
       docker-proxy:
         condition: service_healthy
@@ -68,6 +70,8 @@ services:
       - HOST_HOME=${HOST_HOME}
       - HOST_UID=${HOST_UID:-1000}
       - HOST_GID=${HOST_GID:-1000}
+      # WebSocket server port
+      - WEBSOCKET_PORT=3001
 
   # Build the Claude agent image
   agent-image:

--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
     "@modelcontextprotocol/sdk": "^1.0.0",
     "dockerode": "^4.0.0",
     "glob": "^10.0.0",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/dockerode": "^3.3.0",
     "@types/node": "^20.0.0",
     "@types/uuid": "^9.0.0",
+    "@types/ws": "^8.5.10",
     "tsx": "^4.0.0",
     "typescript": "^5.0.0"
   }

--- a/run-mcp.sh
+++ b/run-mcp.sh
@@ -41,4 +41,5 @@ EOF
 fi
 
 # Run the MCP server container with stdio attached
-exec docker compose run --rm -T mcp-server
+# --service-ports ensures WebSocket port (3001) is published
+exec docker compose run --rm -T --service-ports mcp-server


### PR DESCRIPTION
## Summary
- Add `ws ^8.18.0` and `@types/ws ^8.5.10` to package.json
- Add port mapping `3001:3001` to docker-compose.yml
- Add `WEBSOCKET_PORT=3001` environment variable
- Update run-mcp.sh with `--service-ports` flag for port exposure

## Files
- `package.json` - New dependencies
- `docker-compose.yml` - Port mapping
- `run-mcp.sh` - Service ports flag

Part of #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)