### PR TITLE
🔍 Log level filtering for WebSocket subscriptions

### DIFF
--- a/src/websocket/server.ts
+++ b/src/websocket/server.ts
@@ -271,6 +271,9 @@ export class PinocchioWebSocket {
   broadcast(event: AgentEvent): void {
     for (const [ws, state] of this.clients) {
       // Check if client is subscribed to this agent or '*'
+      // Subscription precedence: specific agent subscription takes precedence over wildcard ('*').
+      // If a client has both a subscription for a specific agentId AND a wildcard subscription
+      // with different log levels, only the specific subscription's log levels are used.
       const levels = state.subscriptions.get(event.agentId) || state.subscriptions.get('*');
       if (!levels) continue;
 


### PR DESCRIPTION
## Summary
- Add LogLevel type and optional logLevels field to SubscribeMessage
- Update ClientState subscriptions to Map<string, Set<LogLevel>> for level tracking
- Filter log events by subscribed levels in broadcast and buffered event replay
- Add type guard validation for logLevels array
- Default to all log levels when not specified

## Test plan
- [ ] Subscribe with specific log levels and verify only those levels are received
- [ ] Subscribe without log levels and verify all levels are received
- [ ] Verify buffered events are also filtered when replaying to new subscribers
- [ ] Verify invalid logLevels in subscribe message are rejected

Part of Issue #27 - Phase 2: Real-time Log Streaming

🤖 Generated with [Claude Code](https://claude.ai/code)