### PR TITLE
fix: Remove redundant dynamic fs import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -507,7 +507,6 @@ async function spawnDockerAgent(args: {
 
   try {
     // Verify workspace path exists
-    const fs = await import("fs/promises");
     const stats = await fs.stat(workspace_path);
     if (!stats.isDirectory()) {
       throw new Error(`Workspace path is not a directory: ${workspace_path}`);


### PR DESCRIPTION
## Summary

This PR fixes a code quality issue by removing a redundant dynamic `import("fs/promises")` inside the `spawnDockerAgent` function.

Fixes #15

## Changes

### `src/index.ts`
- Removed the redundant dynamic import at line 510: `const fs = await import("fs/promises");`
- The module-level import at line 14 (`import * as fs from "fs/promises";`) is already available and should be used instead

## Before
```typescript
// Line 14
import * as fs from "fs/promises";

// ...

// Line 510 (inside spawnDockerAgent)
const fs = await import("fs/promises");  // Redundant!
const stats = await fs.stat(workspace_path);
```

## After
```typescript
// Line 14
import * as fs from "fs/promises";

// ...

// Inside spawnDockerAgent - now uses module-level fs directly
const stats = await fs.stat(workspace_path);
```

---
This is a Gittensor contribution
gittensor::146701565