### PR TITLE
🔌 Phase 2: Add HTTP spawn endpoint for child agents

### DIFF
--- a/src/websocket/server.ts
+++ b/src/websocket/server.ts
@@ -4,7 +4,7 @@
  */
 
 import { WebSocketServer, WebSocket } from 'ws';
-import { createServer, IncomingMessage, Server } from 'http';
+import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
 import { createServer as createHttpsServer } from 'https';
 import { createConnection } from 'net';
 import { unlinkSync, existsSync } from 'fs';
@@ -18,6 +18,12 @@ import {
   ErrorCodes,
   LogLevel,
   isClientMessage,
+  SpawnRequest,
+  SpawnResponse,
+  SpawnErrorResponse,
+  SpawnHandler,
+  TokenValidator,
+  isSpawnRequest,
 } from './types.js';
 import { RingBuffer } from './buffer.js';
 import { EventBus } from './events.js';
@@ -46,28 +52,64 @@ export class PinocchioWebSocket {
   private eventBus: EventBus;
   private heartbeatInterval: NodeJS.Timeout | null = null;
 
+  // Issue #50: Handler functions for spawn endpoint
+  private spawnHandler: SpawnHandler | null = null;
+  private tokenValidator: TokenValidator | null = null;
+
   private readonly HEARTBEAT_INTERVAL = 30000; // 30 seconds
   private readonly CONNECTION_TIMEOUT = 60000; // 60 seconds
+  private readonly MAX_REQUEST_BODY_SIZE = 1024 * 1024; // 1MB max request body
 
   constructor(private config: WebSocketConfig) {
     this.eventBus = EventBus.getInstance(config.bufferSize);
   }
 
   /**
+   * Issue #50: Register the spawn handler function.
+   * This should be called from index.ts to provide access to spawnDockerAgent.
+   */
+  setSpawnHandler(handler: SpawnHandler): void {
+    this.spawnHandler = handler;
+    console.error('[pinocchio-ws] Spawn handler registered');
+  }
+
+  /**
+   * Issue #50: Register the token validator function.
+   * This should be called from index.ts to provide access to validateSessionToken.
+   */
+  setTokenValidator(validator: TokenValidator): void {
+    this.tokenValidator = validator;
+    console.error('[pinocchio-ws] Token validator registered');
+  }
+
+  /**
    * Start the WebSocket server.
    */
   start(): void {
-    // Create HTTP server
-    this.httpServer = createServer();
+    // Issue #50: Create HTTP server with request handler for HTTP endpoints
+    this.httpServer = createServer((req, res) => {
+      this.handleHttpRequest(req, res);
+    });
 
-    // Create WebSocket server
+    // Create WebSocket server with noServer option for upgrade handling
     this.wss = new WebSocketServer({
-      server: this.httpServer,
+      noServer: true,
       maxPayload: 1024 * 1024, // 1MB max message size
-      verifyClient: (info, callback) => {
-        const authorized = this.authenticate(info.req);
-        callback(authorized, authorized ? undefined : 401, 'Unauthorized');
-      },
+    });
+
+    // Issue #50: Handle HTTP upgrade requests for WebSocket
+    this.httpServer.on('upgrade', (req, socket, head) => {
+      // Authenticate WebSocket upgrade requests
+      const authorized = this.authenticate(req);
+      if (!authorized) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      this.wss!.handleUpgrade(req, socket, head, (ws) => {
+        this.wss!.emit('connection', ws, req);
+      });
     });
 
     // Handle connections
@@ -79,6 +121,9 @@ export class PinocchioWebSocket {
     this.httpServer.listen(this.config.port, this.config.bindAddress, () => {
       console.error(
         `[pinocchio-ws] WebSocket server listening on ${this.config.bindAddress}:${this.config.port}`
+      );
+      console.error(
+        `[pinocchio-ws] HTTP endpoints available: GET /health, POST /api/v1/spawn`
       );
     });
 
@@ -376,5 +421,216 @@ export class PinocchioWebSocket {
    */
   getEventBus(): EventBus {
     return this.eventBus;
+  }
+
+  // ============================================================================
+  // Issue #50: HTTP Request Handling
+  // ============================================================================
+
+  /**
+   * Handle incoming HTTP requests.
+   * Routes to appropriate handler based on method and path.
+   */
+  private handleHttpRequest(req: IncomingMessage, res: ServerResponse): void {
+    const url = req.url || '/';
+
+    // GET /health - Health check endpoint
+    if (req.method === 'GET' && url === '/health') {
+      this.handleHealthRequest(res);
+      return;
+    }
+
+    // POST /api/v1/spawn - Spawn child agent endpoint
+    if (req.method === 'POST' && url === '/api/v1/spawn') {
+      this.handleSpawnRequest(req, res);
+      return;
+    }
+
+    // 404 for unknown routes
+    this.sendJsonResponse(res, 404, { error: 'Not Found' });
+  }
+
+  /**
+   * Handle GET /health endpoint.
+   */
+  private handleHealthRequest(res: ServerResponse): void {
+    this.sendJsonResponse(res, 200, {
+      status: 'ok',
+      service: 'pinocchio-websocket',
+      clients: this.clients.size,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Handle POST /api/v1/spawn endpoint.
+   * Allows authenticated child agents to spawn more children.
+   */
+  private async handleSpawnRequest(
+    req: IncomingMessage,
+    res: ServerResponse
+  ): Promise<void> {
+    const startTime = Date.now();
+
+    // Check if handlers are registered
+    if (!this.spawnHandler || !this.tokenValidator) {
+      console.error('[pinocchio-ws] Spawn endpoint called but handlers not registered');
+      this.sendJsonResponse(res, 503, {
+        error: 'Spawn service not available',
+      } as SpawnErrorResponse);
+      return;
+    }
+
+    // Extract and validate Authorization header
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      this.sendJsonResponse(res, 401, {
+        error: 'Missing or invalid Authorization header',
+      } as SpawnErrorResponse);
+      return;
+    }
+
+    const token = authHeader.slice(7); // Remove 'Bearer ' prefix
+    const validation = this.tokenValidator(token);
+
+    if (!validation.valid || !validation.token) {
+      console.error(`[pinocchio-ws] Token validation failed: ${validation.error}`);
+      this.sendJsonResponse(res, 401, {
+        error: validation.error || 'Invalid or expired session token',
+      } as SpawnErrorResponse);
+      return;
+    }
+
+    // Check spawn permission
+    if (!validation.token.permissions.canSpawn) {
+      console.error(
+        `[pinocchio-ws] Spawn permission denied for agent ${validation.token.agentId} (depth: ${validation.token.depth}, maxDepth: ${validation.token.maxDepth})`
+      );
+      this.sendJsonResponse(res, 403, {
+        error: 'Spawn permission denied (depth limit reached)',
+      } as SpawnErrorResponse);
+      return;
+    }
+
+    // Parse request body
+    let body: SpawnRequest;
+    try {
+      body = await this.parseJsonBody(req);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Invalid request body';
+      this.sendJsonResponse(res, 400, { error: message } as SpawnErrorResponse);
+      return;
+    }
+
+    // Validate request body
+    if (!isSpawnRequest(body)) {
+      this.sendJsonResponse(res, 400, {
+        error: 'Invalid request body: task is required and must be a non-empty string',
+      } as SpawnErrorResponse);
+      return;
+    }
+
+    // Calculate effective timeout (capped at parent's remaining time)
+    const parentRemaining = validation.token.expiresAt - Date.now();
+    const requestedTimeout = body.timeout_ms || 3600000; // Default 1 hour
+    const effectiveTimeout = Math.min(requestedTimeout, parentRemaining);
+
+    // Don't allow spawn if parent is about to expire
+    if (effectiveTimeout < 60000) {
+      // Less than 1 minute
+      this.sendJsonResponse(res, 400, {
+        error: 'Insufficient time remaining for child agent (parent expires soon)',
+      } as SpawnErrorResponse);
+      return;
+    }
+
+    console.error(
+      `[pinocchio-ws] Spawn request from agent ${validation.token.agentId}: task="${body.task.slice(0, 50)}..."`
+    );
+
+    // Call the spawn handler (blocking until child completes)
+    try {
+      const result = await this.spawnHandler({
+        task: body.task,
+        workspace_path: body.workspace_path || '/workspace',
+        writable_paths: body.writable_paths,
+        timeout_ms: effectiveTimeout,
+        parent_agent_id: validation.token.agentId,
+      });
+
+      if (result.success) {
+        const response: SpawnResponse = {
+          agent_id: result.agent_id!,
+          status: result.status || 'completed',
+          exit_code: result.exit_code ?? 0,
+          output: result.output || '',
+          duration_ms: result.duration_ms || Date.now() - startTime,
+          files_modified: result.files_modified,
+        };
+        this.sendJsonResponse(res, 200, response);
+      } else {
+        this.sendJsonResponse(res, 500, {
+          error: result.error || 'Spawn failed',
+        } as SpawnErrorResponse);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Internal server error';
+      console.error(`[pinocchio-ws] Spawn handler error: ${message}`);
+      this.sendJsonResponse(res, 500, { error: message } as SpawnErrorResponse);
+    }
+  }
+
+  /**
+   * Parse JSON body from incoming request.
+   */
+  private parseJsonBody(req: IncomingMessage): Promise<SpawnRequest> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      let size = 0;
+
+      req.on('data', (chunk: Buffer) => {
+        size += chunk.length;
+        if (size > this.MAX_REQUEST_BODY_SIZE) {
+          req.destroy();
+          reject(new Error('Request body too large'));
+          return;
+        }
+        chunks.push(chunk);
+      });
+
+      req.on('end', () => {
+        try {
+          const body = Buffer.concat(chunks).toString('utf-8');
+          if (!body.trim()) {
+            reject(new Error('Empty request body'));
+            return;
+          }
+          const parsed = JSON.parse(body);
+          resolve(parsed);
+        } catch {
+          reject(new Error('Invalid JSON'));
+        }
+      });
+
+      req.on('error', (error) => {
+        reject(error);
+      });
+    });
+  }
+
+  /**
+   * Send a JSON response.
+   */
+  private sendJsonResponse(
+    res: ServerResponse,
+    statusCode: number,
+    data: unknown
+  ): void {
+    const body = JSON.stringify(data);
+    res.writeHead(statusCode, {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(body),
+    });
+    res.end(body);
   }
 }


### PR DESCRIPTION
## Summary

Adds HTTP POST `/api/v1/spawn` endpoint that allows child agents to spawn more children.

## New HTTP API

### POST /api/v1/spawn
```
Authorization: Bearer <session-token>
Content-Type: application/json

{
  "task": "Analyze the frontend code",
  "workspace_path": "/workspace/src/frontend",
  "writable_paths": ["src/"],
  "timeout_ms": 3600000
}

Response 200:
{
  "agent_id": "claude-agent-abc123",
  "status": "completed",
  "exit_code": 0,
  "output": "...",
  "duration_ms": 45000,
  "files_modified": ["src/file.ts"]
}
```

### GET /health
```
Response 200:
{
  "status": "ok",
  "service": "pinocchio-websocket",
  "clients": 2,
  "timestamp": "2026-01-18T12:00:00.000Z"
}
```

## Changes

### Types (`src/websocket/types.ts`)
- `SpawnRequest`, `SpawnResponse`, `SpawnErrorResponse`
- `TokenValidationResult`, `SpawnHandlerArgs/Result`
- `isSpawnRequest()` type guard

### Server (`src/websocket/server.ts`)
- Switch to `noServer` mode for HTTP handling
- Route requests to endpoints
- Session token validation
- Permission checking
- Timeout capping

### Integration (`src/index.ts`)
- `validateSessionTokenForHttp()` adapter
- `handleSpawnFromHttp()` wrapper
- Handler registration

## Issue

Closes #50

---
🤖 Implemented by `http-endpoint-architect` agent