### PR TITLE
⏳ Phase 2: Implement blocking spawn behavior (#52)

### DIFF
--- a/src/websocket/types.ts
+++ b/src/websocket/types.ts
@@ -235,11 +235,12 @@ export interface SpawnRequest {
  */
 export interface SpawnResponse {
   agent_id: string;
-  status: 'completed' | 'failed';
+  status: 'completed' | 'failed' | 'timeout';
   exit_code: number;
   output: string;
   duration_ms: number;
   files_modified?: string[];
+  error?: string;
 }
 
 /**
@@ -292,7 +293,7 @@ export interface SpawnHandlerArgs {
 export interface SpawnHandlerResult {
   success: boolean;
   agent_id?: string;
-  status?: 'completed' | 'failed';
+  status?: 'completed' | 'failed' | 'timeout';
   exit_code?: number;
   output?: string;
   duration_ms?: number;


### PR DESCRIPTION
## Summary
- Set socket timeout to match child timeout + 5s buffer
- Add parent disconnect handler for graceful handling
- Add 'timeout' status to SpawnResponse
- Add error field for failed/timeout responses

## Changes
- **Modified**: `src/websocket/server.ts` - blocking behavior, timeout, disconnect handler
- **Modified**: `src/websocket/types.ts` - added timeout status, error field

## Test plan
- [ ] Spawn endpoint blocks until child completes
- [ ] HTTP timeout matches child timeout
- [ ] Parent disconnect handled gracefully

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)