### PR TITLE
🐳 Phase 3: Update Dockerfile to include spawn proxy (#55)

### DIFF
--- a/agent-image/.dockerignore
+++ b/agent-image/.dockerignore
@@ -1,0 +1,14 @@
+# Build artifacts - these are built in the container
+spawn-proxy/node_modules
+spawn-proxy/dist
+
+# Editor and IDE files
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/agent-image/Dockerfile
+++ b/agent-image/Dockerfile
@@ -1,6 +1,21 @@
 # Multi-language Claude Agent Image
 # Provides an isolated environment with Claude Code in YOLO mode
 
+# ============================================================================
+# Builder stage - compile spawn proxy TypeScript
+# ============================================================================
+FROM node:20-slim AS builder
+
+# Build spawn proxy
+COPY spawn-proxy/package*.json /build/spawn-proxy/
+WORKDIR /build/spawn-proxy
+RUN npm ci
+COPY spawn-proxy/ /build/spawn-proxy/
+RUN npm run build
+
+# ============================================================================
+# Final stage - runtime environment
+# ============================================================================
 # Pin to specific digest for reproducible builds
 # To update: docker pull ubuntu:24.04 && docker inspect ubuntu:24.04 --format='{{index .RepoDigests 0}}'
 FROM ubuntu:24.04@sha256:7a398144c5a2fa7dbd9362e460779dc6659bd9b19df50f724250c62ca7812eb3
@@ -50,6 +65,15 @@ RUN npm install -g pnpm bun
 
 # Install Claude Code CLI globally
 RUN npm install -g @anthropic-ai/claude-code
+
+# Copy spawn proxy from builder stage
+COPY --from=builder /build/spawn-proxy/dist /opt/pinocchio/spawn-proxy/
+COPY --from=builder /build/spawn-proxy/node_modules /opt/pinocchio/spawn-proxy/node_modules/
+COPY --from=builder /build/spawn-proxy/package.json /opt/pinocchio/spawn-proxy/
+
+# Create spawn proxy launcher script
+RUN echo '#!/bin/sh\nnode /opt/pinocchio/spawn-proxy/index.js "$@"' > /usr/local/bin/spawn-proxy && \
+    chmod +x /usr/local/bin/spawn-proxy
 
 # Create non-root user for security
 RUN useradd -m -s /bin/bash agent && \


### PR DESCRIPTION
## Summary
Update the agent container Dockerfile to build and include the spawn proxy MCP server.

## Changes
- **Modified**: `agent-image/Dockerfile` - Add builder stage and spawn proxy installation
- **New**: `agent-image/.dockerignore` - Exclude build artifacts

## Details
- Builder stage using `node:20-slim` to compile TypeScript
- Spawn proxy installed at `/opt/pinocchio/spawn-proxy/`
- Launcher script at `/usr/local/bin/spawn-proxy`

## Test plan
- [ ] Docker image builds successfully
- [ ] Spawn proxy launcher works in container

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)