### PR TITLE
🔧 Phase 3: Update entrypoint.sh to configure spawn proxy (#56)

### DIFF
--- a/agent-image/entrypoint.sh
+++ b/agent-image/entrypoint.sh
@@ -56,6 +56,26 @@ if [ -n "$AGENT_WORKDIR" ] && [ -d "$AGENT_WORKDIR" ]; then
     cd "$AGENT_WORKDIR"
 fi
 
+# Configure spawn proxy MCP server for nested agent spawning
+if [ -n "$PINOCCHIO_API_URL" ] && [ -n "$PINOCCHIO_SESSION_TOKEN" ]; then
+    mkdir -p ~/.config/claude
+    cat > ~/.config/claude/mcp_servers.json << EOF
+{
+  "spawn-proxy": {
+    "command": "/usr/local/bin/spawn-proxy",
+    "args": [],
+    "env": {
+      "PINOCCHIO_API_URL": "$PINOCCHIO_API_URL",
+      "PINOCCHIO_SESSION_TOKEN": "$PINOCCHIO_SESSION_TOKEN"
+    }
+  }
+}
+EOF
+    echo "[entrypoint] Spawn proxy MCP server configured"
+else
+    echo "[entrypoint] Spawn proxy not configured (PINOCCHIO_API_URL or PINOCCHIO_SESSION_TOKEN not set)"
+fi
+
 echo "╔══════════════════════════════════════════╗"
 echo "║       🤖 Claude Agent Starting          ║"
 echo "╠══════════════════════════════════════════╣"


### PR DESCRIPTION
## Summary
Update the agent entrypoint script to configure Claude CLI to use the spawn proxy MCP server.

## Changes
- **Modified**: `agent-image/entrypoint.sh`

## Details
- Checks for PINOCCHIO_API_URL and PINOCCHIO_SESSION_TOKEN env vars
- Creates ~/.config/claude/mcp_servers.json with spawn-proxy config
- Logs when spawn proxy is configured or not

## Test plan
- [ ] Agent starts with spawn proxy when env vars set
- [ ] Agent starts without spawn proxy when env vars not set

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)