### PR TITLE
🔧 Phase 4: Implement cascade termination (#58)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1131,7 +1131,7 @@ async function createSecureTokenFile(agentId: string, token: string): Promise<st
 // SECURITY FIX #8.1: Added cleanup flag to prevent double cleanup race condition.
 // Multiple code paths can trigger cleanup (foreground completion, background monitor, error handlers).
 // The cleanedTokenFiles Set ensures each file is only deleted once.
-async function cleanupTokenFile(tokenFilePath: string): Promise<void> {
+export async function cleanupTokenFile(tokenFilePath: string): Promise<void> {
   // SECURITY FIX #8.1: Check if already cleaned up to prevent race condition
   if (cleanedTokenFiles.has(tokenFilePath)) {
     return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,11 @@ import {
   SessionToken,
   TokenValidationResult,
 } from './session/index.js';
+import {
+  terminateWithChildren,
+  terminateTree,
+  CascadeTerminationResult,
+} from './lifecycle/index.js';
 
 // PR #32 FIX: Docker stream demultiplexer
 // Docker multiplexed streams have an 8-byte header per message:
@@ -2813,6 +2818,20 @@ async function getAgentStatus(args: { agent_id: string; tail_lines?: number }) {
   };
 }
 
+// Issue #58: Helper function to update agent metadata for cascade termination
+async function updateAgentMetadataForTermination(
+  agentId: string,
+  status: "failed",
+  output: string
+): Promise<void> {
+  const metadata = agentMetadata.get(agentId);
+  if (metadata && metadata.status === "running") {
+    metadata.status = status;
+    metadata.endedAt = new Date();
+    metadata.output = (metadata.output || "") + "\n" + output;
+  }
+}
+
 // Stop a running agent
 async function stopDockerAgent(args: { agent_id: string }) {
   const { agent_id } = args;
@@ -2830,13 +2849,67 @@ async function stopDockerAgent(args: { agent_id: string }) {
   }
 
   try {
+    const metadata = agentMetadata.get(agent_id);
+
+    // Issue #58: Check if this agent has children and use cascade termination
+    if (metadata && metadata.childAgentIds.length > 0) {
+      console.error(`[pinocchio] Agent ${agent_id} has ${metadata.childAgentIds.length} children, using cascade termination`);
+
+      const cascadeResult = await terminateWithChildren(
+        agent_id,
+        "SIGTERM",
+        updateAgentMetadataForTermination,
+        runningAgents
+      );
+
+      // Persist state after cascade termination
+      await saveAgentState();
+
+      // Issue #46: Check if the tree should be terminated
+      checkAndTerminateTree(metadata.treeId);
+      await saveTreeState();
+
+      // Issue #48: Persist token state after invalidation
+      await saveSessionTokenState();
+
+      // AUDIT FIX #9: Log agent stop event with cascade info
+      const duration_ms = metadata.endedAt
+        ? metadata.endedAt.getTime() - metadata.startedAt.getTime()
+        : undefined;
+      await auditLog("agent.stop", {
+        stopped_by: "user",
+        duration_ms,
+        cascade: true,
+        terminated_count: cascadeResult.terminated.length,
+        failed_count: cascadeResult.failed.length,
+      }, agent_id);
+
+      // Build response with cascade information
+      const failedInfo = cascadeResult.failed.length > 0
+        ? `\n\n**Failed to terminate:**\n${cascadeResult.failed.map(f => `- ${f.agentId}: ${f.error}`).join("\n")}`
+        : "";
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `## 🔗 Cascade Termination Complete\n\n` +
+              `**Root Agent:** ${agent_id}\n` +
+              `**Agents Terminated:** ${cascadeResult.terminated.length}\n` +
+              `**Terminated IDs:** ${cascadeResult.terminated.map(id => `\`${id}\``).join(", ")}` +
+              failedInfo,
+          },
+        ],
+      };
+    }
+
+    // No children - use original single-agent termination logic
     const container = docker.getContainer(agent_id);
     await container.stop();
     await container.remove({ force: true });
     runningAgents.delete(agent_id);
 
     // RELIABILITY FIX #4: Update and persist metadata when agent is manually stopped
-    const metadata = agentMetadata.get(agent_id);
     let duration_ms: number | undefined;
     if (metadata && metadata.status === "running") {
       metadata.status = "failed";

--- a/src/lifecycle/cascade.ts
+++ b/src/lifecycle/cascade.ts
@@ -1,0 +1,179 @@
+/**
+ * Cascade Termination (Issue #58)
+ *
+ * Implements cascade termination so when a parent agent terminates,
+ * all its children are also terminated.
+ */
+
+import Docker from "dockerode";
+import {
+  getAgentMetadata,
+  getSpawnTree,
+  AgentMetadata,
+  SpawnTree,
+} from "../index.js";
+import {
+  invalidateTokensForAgent,
+  invalidateTokensForTree,
+  invalidateSessionToken,
+} from "../session/index.js";
+
+// Docker client for container operations
+const docker = new Docker();
+
+/**
+ * Result of a cascade termination operation
+ */
+export interface CascadeTerminationResult {
+  /** IDs of agents successfully terminated */
+  terminated: string[];
+  /** IDs of agents that failed to terminate with error messages */
+  failed: Array<{ agentId: string; error: string }>;
+  /** Total number of agents processed */
+  totalProcessed: number;
+}
+
+/**
+ * Recursively terminate an agent and all its descendants (depth-first).
+ *
+ * Children are terminated first to ensure proper cleanup order.
+ * Session tokens are invalidated for each agent.
+ *
+ * @param agentId - The ID of the agent to terminate
+ * @param signal - The signal to send (default: 'SIGTERM')
+ * @param updateMetadata - Callback to update agent metadata after termination
+ * @param runningAgents - Map of running agent containers
+ * @returns Result containing terminated and failed agent IDs
+ */
+export async function terminateWithChildren(
+  agentId: string,
+  signal: string = "SIGTERM",
+  updateMetadata: (agentId: string, status: "failed", output: string) => Promise<void>,
+  runningAgents: Map<string, Docker.Container>
+): Promise<CascadeTerminationResult> {
+  const result: CascadeTerminationResult = {
+    terminated: [],
+    failed: [],
+    totalProcessed: 0,
+  };
+
+  const metadata = getAgentMetadata(agentId);
+  if (!metadata) {
+    console.error(`[pinocchio] Cascade termination: Agent ${agentId} not found`);
+    return result;
+  }
+
+  // Terminate children first (depth-first traversal)
+  for (const childId of metadata.childAgentIds) {
+    const childResult = await terminateWithChildren(childId, signal, updateMetadata, runningAgents);
+    result.terminated.push(...childResult.terminated);
+    result.failed.push(...childResult.failed);
+    result.totalProcessed += childResult.totalProcessed;
+  }
+
+  // Now terminate this agent
+  result.totalProcessed++;
+
+  try {
+    // Only terminate if the agent is still running
+    if (metadata.status === "running") {
+      // Invalidate session tokens for this agent
+      if (metadata.sessionToken) {
+        invalidateSessionToken(metadata.sessionToken);
+      }
+      invalidateTokensForAgent(agentId);
+
+      // Stop the container
+      const container = runningAgents.get(agentId);
+      if (container) {
+        try {
+          await container.stop();
+          await container.remove({ force: true });
+        } catch (containerError) {
+          // Container might already be stopped/removed
+          console.error(`[pinocchio] Cascade termination: Container operation for ${agentId}: ${containerError}`);
+        }
+        runningAgents.delete(agentId);
+      } else {
+        // Try to get container directly by ID (might not be in runningAgents map)
+        try {
+          const directContainer = docker.getContainer(agentId);
+          await directContainer.stop();
+          await directContainer.remove({ force: true });
+        } catch (directError) {
+          // Container might not exist or already be stopped
+          console.error(`[pinocchio] Cascade termination: Direct container lookup for ${agentId}: ${directError}`);
+        }
+      }
+
+      // Update metadata
+      await updateMetadata(agentId, "failed", "[pinocchio] Agent terminated via cascade termination");
+      result.terminated.push(agentId);
+      console.error(`[pinocchio] Cascade termination: Terminated agent ${agentId}`);
+    } else {
+      // Agent already terminated, just count it
+      console.error(`[pinocchio] Cascade termination: Agent ${agentId} already in status: ${metadata.status}`);
+      result.terminated.push(agentId);
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    result.failed.push({ agentId, error: errorMessage });
+    console.error(`[pinocchio] Cascade termination: Failed to terminate ${agentId}: ${errorMessage}`);
+  }
+
+  return result;
+}
+
+/**
+ * Terminate an entire spawn tree by its tree ID.
+ *
+ * Finds the root agent of the tree and terminates it along with all descendants.
+ * Also invalidates all session tokens for the tree.
+ *
+ * @param treeId - The ID of the spawn tree to terminate
+ * @param updateMetadata - Callback to update agent metadata after termination
+ * @param runningAgents - Map of running agent containers
+ * @returns Result containing terminated and failed agent IDs
+ */
+export async function terminateTree(
+  treeId: string,
+  updateMetadata: (agentId: string, status: "failed", output: string) => Promise<void>,
+  runningAgents: Map<string, Docker.Container>
+): Promise<CascadeTerminationResult> {
+  const result: CascadeTerminationResult = {
+    terminated: [],
+    failed: [],
+    totalProcessed: 0,
+  };
+
+  const tree = getSpawnTree(treeId);
+  if (!tree) {
+    console.error(`[pinocchio] Cascade termination: Spawn tree ${treeId} not found`);
+    return result;
+  }
+
+  if (tree.status === "terminated") {
+    console.error(`[pinocchio] Cascade termination: Spawn tree ${treeId} already terminated`);
+    return result;
+  }
+
+  // Invalidate all tokens for this tree upfront
+  invalidateTokensForTree(treeId);
+
+  // Terminate starting from the root agent (this will cascade to all children)
+  const cascadeResult = await terminateWithChildren(
+    tree.rootAgentId,
+    "SIGTERM",
+    updateMetadata,
+    runningAgents
+  );
+
+  result.terminated = cascadeResult.terminated;
+  result.failed = cascadeResult.failed;
+  result.totalProcessed = cascadeResult.totalProcessed;
+
+  console.error(`[pinocchio] Cascade termination: Tree ${treeId} terminated. ` +
+    `Terminated: ${result.terminated.length}, Failed: ${result.failed.length}`);
+
+  return result;
+}

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Lifecycle module barrel export
+ *
+ * This module handles agent lifecycle operations including cascade termination.
+ */
+
+export {
+  terminateWithChildren,
+  terminateTree,
+  CascadeTerminationResult,
+} from "./cascade.js";


### PR DESCRIPTION
## Summary
Implement cascade termination so when a parent agent terminates, all its children are also terminated.

## Changes
- **New**: `src/lifecycle/cascade.ts` - Core cascade termination logic
- **New**: `src/lifecycle/index.ts` - Barrel export
- **Modified**: `src/index.ts` - Integrate cascade termination

## Features
- `terminateWithChildren()` - Recursively terminate agent and descendants (depth-first)
- `terminateTree()` - Terminate entire spawn tree
- Automatic cascade when stopping agent with children
- Track all terminated agents in result

## Test plan
- [ ] Parent termination cascades to children
- [ ] Depth-first termination order
- [ ] Session tokens invalidated for all terminated agents

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)