### PR TITLE
🔧 Implement periodic orphan detection and cleanup (Issue #61)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -792,6 +792,11 @@ export function getAgentMetadata(agentId: string): AgentMetadata | undefined {
   return agentMetadata.get(agentId);
 }
 
+// Issue #61: Get all agent metadata (for orphan detection)
+export function getAllAgentMetadata(): Map<string, AgentMetadata> {
+  return agentMetadata;
+}
+
 // Issue #46: Update tree agent count (delta can be positive or negative)
 async function updateTreeAgentCount(treeId: string, delta: number): Promise<void> {
   const tree = spawnTrees.get(treeId);

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -9,3 +9,14 @@ export {
   terminateTree,
   CascadeTerminationResult,
 } from "./cascade.js";
+
+export {
+  detectOrphanedAgents,
+  cleanupOrphanedAgents,
+  startOrphanDetection,
+  stopOrphanDetection,
+  getOrphanDetectionConfig,
+  isOrphanDetectionRunning,
+  OrphanedAgent,
+  OrphanDetectionConfig,
+} from "./orphan.js";

--- a/src/lifecycle/orphan.ts
+++ b/src/lifecycle/orphan.ts
@@ -1,0 +1,187 @@
+/**
+ * Orphan Detection and Cleanup (Issue #61)
+ *
+ * Detects and cleans up child agents whose parents terminated unexpectedly.
+ */
+
+import {
+  getAgentMetadata,
+  getAllAgentMetadata,
+  getSpawnTree,
+} from "../index.js";
+import { terminateWithChildren, CascadeTerminationResult } from "./cascade.js";
+import Docker from "dockerode";
+
+// Default check interval: 60 seconds
+const DEFAULT_ORPHAN_CHECK_INTERVAL_MS = 60000;
+
+export interface OrphanedAgent {
+  agentId: string;
+  parentAgentId: string;
+  reason: "parent_not_found" | "parent_terminated" | "tree_terminated";
+}
+
+export interface OrphanDetectionConfig {
+  checkIntervalMs: number;
+  enabled: boolean;
+}
+
+let orphanCleanupInterval: NodeJS.Timeout | null = null;
+let cleanupConfig: OrphanDetectionConfig = {
+  checkIntervalMs: DEFAULT_ORPHAN_CHECK_INTERVAL_MS,
+  enabled: true,
+};
+
+/**
+ * Detect all orphaned agents (agents with dead/missing parents)
+ */
+export function detectOrphanedAgents(): OrphanedAgent[] {
+  const orphans: OrphanedAgent[] = [];
+  const allMetadata = getAllAgentMetadata();
+
+  for (const [agentId, metadata] of allMetadata) {
+    if (metadata.status !== "running") continue;
+    if (!metadata.parentAgentId) continue; // Root agents can't be orphaned
+
+    const parent = getAgentMetadata(metadata.parentAgentId);
+
+    if (!parent) {
+      orphans.push({
+        agentId,
+        parentAgentId: metadata.parentAgentId,
+        reason: "parent_not_found",
+      });
+      continue;
+    }
+
+    if (parent.status !== "running") {
+      orphans.push({
+        agentId,
+        parentAgentId: metadata.parentAgentId,
+        reason: "parent_terminated",
+      });
+      continue;
+    }
+
+    // Check if the tree is terminated
+    if (metadata.treeId) {
+      const tree = getSpawnTree(metadata.treeId);
+      if (tree && tree.status === "terminated") {
+        orphans.push({
+          agentId,
+          parentAgentId: metadata.parentAgentId,
+          reason: "tree_terminated",
+        });
+      }
+    }
+  }
+
+  return orphans;
+}
+
+/**
+ * Clean up all detected orphaned agents
+ */
+export async function cleanupOrphanedAgents(
+  updateMetadata: (
+    agentId: string,
+    status: "failed",
+    output: string
+  ) => Promise<void>,
+  runningAgents: Map<string, Docker.Container>
+): Promise<{ cleaned: number; results: CascadeTerminationResult[] }> {
+  const orphans = detectOrphanedAgents();
+  const results: CascadeTerminationResult[] = [];
+
+  for (const orphan of orphans) {
+    console.error(
+      `[pinocchio] Orphan detection: Cleaning up orphaned agent ${orphan.agentId} (reason: ${orphan.reason})`
+    );
+
+    const result = await terminateWithChildren(
+      orphan.agentId,
+      "SIGTERM",
+      updateMetadata,
+      runningAgents
+    );
+    results.push(result);
+  }
+
+  return { cleaned: orphans.length, results };
+}
+
+/**
+ * Start periodic orphan detection
+ */
+export function startOrphanDetection(
+  updateMetadata: (
+    agentId: string,
+    status: "failed",
+    output: string
+  ) => Promise<void>,
+  runningAgents: Map<string, Docker.Container>,
+  config?: Partial<OrphanDetectionConfig>
+): void {
+  if (config) {
+    cleanupConfig = { ...cleanupConfig, ...config };
+  }
+
+  if (!cleanupConfig.enabled) {
+    console.error("[pinocchio] Orphan detection disabled by configuration");
+    return;
+  }
+
+  if (orphanCleanupInterval) {
+    console.error("[pinocchio] Orphan detection already running");
+    return;
+  }
+
+  console.error(
+    `[pinocchio] Starting orphan detection (interval: ${cleanupConfig.checkIntervalMs}ms)`
+  );
+
+  orphanCleanupInterval = setInterval(async () => {
+    try {
+      const { cleaned, results } = await cleanupOrphanedAgents(
+        updateMetadata,
+        runningAgents
+      );
+      if (cleaned > 0) {
+        const totalTerminated = results.reduce(
+          (sum, r) => sum + r.terminated.length,
+          0
+        );
+        console.error(
+          `[pinocchio] Orphan detection: Cleaned up ${cleaned} orphaned agents (${totalTerminated} total terminated)`
+        );
+      }
+    } catch (error) {
+      console.error("[pinocchio] Orphan detection error:", error);
+    }
+  }, cleanupConfig.checkIntervalMs);
+}
+
+/**
+ * Stop periodic orphan detection
+ */
+export function stopOrphanDetection(): void {
+  if (orphanCleanupInterval) {
+    clearInterval(orphanCleanupInterval);
+    orphanCleanupInterval = null;
+    console.error("[pinocchio] Orphan detection stopped");
+  }
+}
+
+/**
+ * Get current orphan detection configuration
+ */
+export function getOrphanDetectionConfig(): OrphanDetectionConfig {
+  return { ...cleanupConfig };
+}
+
+/**
+ * Check if orphan detection is running
+ */
+export function isOrphanDetectionRunning(): boolean {
+  return orphanCleanupInterval !== null;
+}


### PR DESCRIPTION
## Summary
- Implements periodic orphan detection to clean up child agents whose parents terminated unexpectedly
- Adds `src/lifecycle/orphan.ts` with detection and cleanup functions
- Exports `getAllAgentMetadata()` for iteration over all agents

## Changes
- **New file `src/lifecycle/orphan.ts`**:
  - `detectOrphanedAgents()` - finds orphans by checking parent status
  - `cleanupOrphanedAgents()` - terminates orphans via cascade termination
  - `startOrphanDetection()` / `stopOrphanDetection()` - periodic check management
  - Configurable interval (default 60s) and enable/disable flag

- **Updated `src/lifecycle/index.ts`** - exports new functions and types

- **Updated `src/index.ts`** - adds `getAllAgentMetadata()` function

## Orphan Detection Reasons
1. `parent_not_found` - parent agent doesn't exist in metadata
2. `parent_terminated` - parent agent's status is not "running"
3. `tree_terminated` - the spawn tree is marked as terminated

## Test plan
- [ ] Verify orphan detection finds agents with terminated parents
- [ ] Verify cascade termination cleans up orphans properly
- [ ] Verify periodic detection runs at configured interval
- [ ] Verify detection can be started/stopped

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)