### PR TITLE
🔔 Update get_agent_status to show child agents (Issue #64)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1358,7 +1358,7 @@ The agent runs with full autonomy (YOLO mode) inside a secured container with:
   },
   {
     name: "get_agent_status",
-    description: `Get the status and output of a running or completed agent.
+    description: `Get the status and output of a running or completed agent. Includes hierarchy info (treeId, depth, childAgentIds). Set include_children: true for detailed child agent summaries.
 
 Returns:
 - Current status (running/completed/failed)


### PR DESCRIPTION
## Summary
- Add `include_children` parameter to `get_agent_status` tool to optionally include detailed child agent summaries
- Always include hierarchy fields in the response: `parentAgentId`, `treeId`, `depth`, `childAgentIds`, `childCount`
- Add `ChildAgentSummary` interface and `getChildAgentSummaries` helper function
- When `include_children=true`, response includes a table of child agent details (ID, status, truncated task)

## Test plan
- [ ] Call `get_agent_status` on an agent without children - should show `childCount: 0`
- [ ] Call `get_agent_status` on an agent with children - should show all child IDs and count
- [ ] Call `get_agent_status` with `include_children: true` on agent with children - should show detailed child table
- [ ] Verify `treeId` and `depth` fields are always present in response

Closes #64

🤖 Generated with [Claude Code](https://claude.ai/code)