### PR TITLE
🔔 Emit cascade termination events (Issue #65)

### DIFF
--- a/src/lifecycle/orphan.ts
+++ b/src/lifecycle/orphan.ts
@@ -98,11 +98,15 @@ export async function cleanupOrphanedAgents(
       `[pinocchio] Orphan detection: Cleaning up orphaned agent ${orphan.agentId} (reason: ${orphan.reason})`
     );
 
+    // Pass orphan_cleanup as the reason for the initial orphan,
+    // children will be terminated with 'cascade' reason
     const result = await terminateWithChildren(
       orphan.agentId,
       "SIGTERM",
       updateMetadata,
-      runningAgents
+      runningAgents,
+      undefined, // no initiatorAgentId for orphan cleanup
+      'orphan_cleanup'
     );
     results.push(result);
   }


### PR DESCRIPTION
## Summary
Emit WebSocket terminated events during cascade termination.

## Changes
- **`src/lifecycle/cascade.ts`**:
  - Import `eventBus` from websocket events
  - Add `emitTerminated()` call after updating agent status
  - Pass reason (cascade/manual/timeout/orphan_cleanup) and initiatorAgentId
  - Add `TerminationReason` type export

- **`src/lifecycle/orphan.ts`**:
  - Pass `orphan_cleanup` reason when calling terminateWithChildren

## Test plan
- [ ] Verify terminated events emit with correct reason
- [ ] Verify initiatorAgentId is included for cascade
- [ ] Build passes

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)