### PR TITLE
🔔 Add tree-level WebSocket subscription (Issue #63)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import * as path from "path";
 import * as fs from "fs/promises";
 import { glob } from "glob";
 import * as crypto from "crypto";
-import { EventBus } from './websocket/events.js';
+import { EventBus, eventBus } from './websocket/events.js';
 import { PinocchioWebSocket } from './websocket/server.js';
 import { WebSocketConfig, SpawnHandlerArgs, SpawnHandlerResult, TokenValidationResult as WsTokenValidationResult } from './websocket/types.js';
 import { ProgressTracker } from './websocket/progress.js';
@@ -826,6 +826,8 @@ function terminateSpawnTree(treeId: string): void {
     // Issue #48: Invalidate all session tokens for this tree
     // Tokens are no longer valid once a tree is terminated
     invalidateTokensForTree(treeId);
+    // PR #86: Clean up tree buffer to prevent memory leak
+    eventBus.clearTreeBuffer(treeId);
     console.error(`[pinocchio] Spawn tree terminated: ${treeId}`);
   }
 }

--- a/src/lifecycle/cascade.ts
+++ b/src/lifecycle/cascade.ts
@@ -18,6 +18,7 @@ import {
   invalidateTokensForTree,
   invalidateSessionToken,
 } from "../session/index.js";
+import { eventBus } from "../websocket/events.js";
 
 // Docker client for container operations
 const docker = new Docker();
@@ -189,6 +190,9 @@ export async function terminateTree(
   result.terminated = cascadeResult.terminated;
   result.failed = cascadeResult.failed;
   result.totalProcessed = cascadeResult.totalProcessed;
+
+  // PR #86: Clean up tree buffer to prevent memory leak
+  eventBus.clearTreeBuffer(treeId);
 
   console.error(`[pinocchio] Cascade termination: Tree ${treeId} terminated. ` +
     `Terminated: ${result.terminated.length}, Failed: ${result.failed.length}`);


### PR DESCRIPTION
## Summary
Allow clients to subscribe to all events in a spawn tree by treeId.

## Changes
- **`src/websocket/types.ts`**:
  - Add `treeId` field to Subscribe/Unsubscribe messages
  - Update type guards to validate either agentId or treeId

- **`src/websocket/server.ts`**:
  - Add `treeSubscriptions` map to ClientState
  - Update handleSubscribe/handleUnsubscribe for tree support
  - Update broadcast to check tree subscriptions
  - Prevent duplicate events when subscribed via both

- **`src/websocket/events.ts`**:
  - Add tree event buffering
  - Add `getBufferedEventsByTree()` and `clearTreeBuffer()`

## Usage
```typescript
// Subscribe to all events in a tree
{ type: 'subscribe', treeId: 'tree-abc123', logLevels: ['info'] }

// Unsubscribe
{ type: 'unsubscribe', treeId: 'tree-abc123' }
```

## Test plan
- [ ] Verify tree subscription receives all tree events
- [ ] Verify no duplicates when subscribed to both agent and tree
- [ ] Build passes

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)