### PR TITLE
Fix: Replace WebSocket with UDS (Issue #44)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__pinocchio__get_agent_status",
+      "Bash(gh issue view:*)"
+    ]
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ services:
       - ${HOST_CONFIG_DIR:-~/.config/pinocchio}:/root/.config/pinocchio:rw
       # GitHub CLI config (for gh commands in agents)
       - ${HOST_GH_CONFIG:-~/.config/gh}:/root/.config/gh:ro
+      # Share socket directory with host for nested agent access
+      - /tmp/pinocchio:/tmp/pinocchio:rw
     networks:
       - docker-proxy
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       context: .
       dockerfile: Dockerfile
     image: pinocchio:latest
-    # Issue #44: Port 3001 removed - now using Unix Domain Socket at /tmp/pinocchio-{PID}.sock
+    # Issue #44: Port 3001 removed - now using Unix Domain Socket at /tmp/pinocchio/mcp.sock
     # This eliminates port conflicts from stale containers
     depends_on:
       docker-proxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,8 @@ services:
       context: .
       dockerfile: Dockerfile
     image: pinocchio:latest
-    ports:
-      - "3001:3001"  # WebSocket server
+    # Issue #44: Port 3001 removed - now using Unix Domain Socket at /tmp/pinocchio-{PID}.sock
+    # This eliminates port conflicts from stale containers
     depends_on:
       docker-proxy:
         condition: service_healthy

--- a/run-mcp.sh
+++ b/run-mcp.sh
@@ -29,6 +29,9 @@ export HOST_GH_CONFIG="${HOST_GH_CONFIG:-$HOME/.config/gh}"
 # Ensure config directory exists
 mkdir -p "$HOST_CONFIG_DIR"
 
+# Create socket directory on host for UDS sharing with agents
+mkdir -p /tmp/pinocchio
+
 # Create default config if it doesn't exist
 if [ ! -f "$HOST_CONFIG_DIR/config.json" ]; then
   cat > "$HOST_CONFIG_DIR/config.json" << EOF

--- a/run-mcp.sh
+++ b/run-mcp.sh
@@ -41,5 +41,5 @@ EOF
 fi
 
 # Run the MCP server container with stdio attached
-# --service-ports ensures WebSocket port (3001) is published
-exec docker compose run --rm -T --service-ports mcp-server
+# Issue #44: WebSocket now uses Unix Domain Socket (no port needed)
+exec docker compose run --rm -T mcp-server

--- a/src/index.ts
+++ b/src/index.ts
@@ -958,7 +958,7 @@ async function cascadeTerminateChildren(agentId: string): Promise<void> {
       const result = await terminateWithChildren(
         childId,
         "SIGTERM",
-        updateAgentMetadataForCascade,
+        updateAgentMetadataForTermination,
         runningAgents,
         agentId, // This agent initiated the cascade
         "cascade"

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,7 +325,17 @@ interface AuditEvent {
 async function loadConfig(): Promise<AgentConfig> {
   try {
     const data = await fs.readFile(CONFIG_FILE, "utf-8");
-    return { ...DEFAULT_CONFIG, ...JSON.parse(data) };
+    const persisted = JSON.parse(data);
+    // Deep merge websocket config to preserve defaults like unixSocket
+    // when existing configs don't have the new field
+    return {
+      ...DEFAULT_CONFIG,
+      ...persisted,
+      websocket: {
+        ...DEFAULT_CONFIG.websocket,
+        ...persisted.websocket,
+      },
+    };
   } catch {
     return DEFAULT_CONFIG;
   }

--- a/src/websocket/server.ts
+++ b/src/websocket/server.ts
@@ -165,11 +165,14 @@ export class PinocchioWebSocket {
       // Handle WebSocket upgrades on Unix socket
       this.setupUpgradeHandler(this.unixServer);
 
-      this.unixServer.listen(this.config.unixSocket, () => {
+      const socketPath = this.config.unixSocket;
+      this.unixServer.listen(socketPath, () => {
         // Set socket permissions to allow non-root agents (UID 1000) to connect
-        chmodSync(this.config.unixSocket, 0o777);
+        if (socketPath) {
+          chmodSync(socketPath, 0o777);
+        }
         console.error(
-          `[pinocchio-ws] WebSocket server listening on Unix socket: ${this.config.unixSocket}`
+          `[pinocchio-ws] WebSocket server listening on Unix socket: ${socketPath}`
         );
         console.error(
           `[pinocchio-ws] HTTP endpoints available: GET /health, POST /api/v1/spawn`

--- a/src/websocket/server.ts
+++ b/src/websocket/server.ts
@@ -7,7 +7,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
 import { createServer as createHttpsServer } from 'https';
 import { createConnection } from 'net';
-import { unlinkSync, existsSync, mkdirSync, promises as fs } from 'fs';
+import { unlinkSync, existsSync, mkdirSync, chmodSync, promises as fs } from 'fs';
 import { timingSafeEqual } from 'crypto';
 import * as path from 'path';
 import * as os from 'os';
@@ -166,6 +166,8 @@ export class PinocchioWebSocket {
       this.setupUpgradeHandler(this.unixServer);
 
       this.unixServer.listen(this.config.unixSocket, () => {
+        // Set socket permissions to allow non-root agents (UID 1000) to connect
+        chmodSync(this.config.unixSocket, 0o777);
         console.error(
           `[pinocchio-ws] WebSocket server listening on Unix socket: ${this.config.unixSocket}`
         );

--- a/src/websocket/server.ts
+++ b/src/websocket/server.ts
@@ -124,8 +124,13 @@ export class PinocchioWebSocket {
     console.error('[pinocchio-ws] Quota config getter registered');
   }
 
+  // Issue #44: Track Unix socket server for cleanup
+  private unixServer: Server | null = null;
+
   /**
    * Start the WebSocket server.
+   * Issue #44: UDS (Unix Domain Socket) is now the primary listening mode.
+   * TCP port is only used as fallback if unixSocket is not configured.
    */
   start(): void {
     // Issue #50: Create HTTP server with request handler for HTTP endpoints
@@ -159,31 +164,53 @@ export class PinocchioWebSocket {
       this.handleConnection(ws, req);
     });
 
-    // Start listening on TCP port
-    this.httpServer.listen(this.config.port, this.config.bindAddress, () => {
-      console.error(
-        `[pinocchio-ws] WebSocket server listening on ${this.config.bindAddress}:${this.config.port}`
-      );
-      console.error(
-        `[pinocchio-ws] HTTP endpoints available: GET /health, POST /api/v1/spawn`
-      );
-    });
-
-    // Optionally listen on Unix socket
+    // Issue #44: Use Unix Domain Socket as primary listener to avoid port conflicts
     if (this.config.unixSocket) {
-      // Remove existing socket file
+      // Clean up stale socket file (from crashed processes)
       if (existsSync(this.config.unixSocket)) {
+        console.error(
+          `[pinocchio-ws] Cleaning up stale socket file: ${this.config.unixSocket}`
+        );
         unlinkSync(this.config.unixSocket);
       }
 
-      const unixServer = createServer();
-      const unixWss = new WebSocketServer({ server: unixServer });
-      unixWss.on('connection', (ws, req) => {
-        this.handleConnection(ws, req);
+      // Create Unix socket server with HTTP handler
+      this.unixServer = createServer((req, res) => {
+        this.handleHttpRequest(req, res);
       });
-      unixServer.listen(this.config.unixSocket, () => {
+
+      // Handle WebSocket upgrades on Unix socket
+      this.unixServer.on('upgrade', (req, socket, head) => {
+        const authorized = this.authenticate(req);
+        if (!authorized) {
+          socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+          socket.destroy();
+          return;
+        }
+        this.wss!.handleUpgrade(req, socket, head, (ws) => {
+          this.wss!.emit('connection', ws, req);
+        });
+      });
+
+      this.unixServer.listen(this.config.unixSocket, () => {
         console.error(
-          `[pinocchio-ws] WebSocket server listening on ${this.config.unixSocket}`
+          `[pinocchio-ws] WebSocket server listening on Unix socket: ${this.config.unixSocket}`
+        );
+        console.error(
+          `[pinocchio-ws] HTTP endpoints available: GET /health, POST /api/v1/spawn`
+        );
+      });
+
+      // Issue #44: Register cleanup handlers for process exit
+      this.registerCleanupHandlers();
+    } else {
+      // Fallback: TCP port (only if unixSocket is not configured)
+      this.httpServer.listen(this.config.port, this.config.bindAddress, () => {
+        console.error(
+          `[pinocchio-ws] WebSocket server listening on ${this.config.bindAddress}:${this.config.port}`
+        );
+        console.error(
+          `[pinocchio-ws] HTTP endpoints available: GET /health, POST /api/v1/spawn`
         );
       });
     }
@@ -195,6 +222,43 @@ export class PinocchioWebSocket {
 
     // Start heartbeat check
     this.startHeartbeat();
+  }
+
+  /**
+   * Issue #44: Register cleanup handlers to remove socket file on process exit.
+   * This handles SIGINT, SIGTERM, and uncaught exceptions.
+   */
+  private registerCleanupHandlers(): void {
+    const cleanup = () => {
+      if (this.config.unixSocket && existsSync(this.config.unixSocket)) {
+        try {
+          unlinkSync(this.config.unixSocket);
+          console.error(`[pinocchio-ws] Cleaned up socket file: ${this.config.unixSocket}`);
+        } catch (err) {
+          // Ignore errors during cleanup
+        }
+      }
+    };
+
+    // Handle graceful shutdown signals
+    process.once('SIGINT', () => {
+      cleanup();
+      process.exit(0);
+    });
+    process.once('SIGTERM', () => {
+      cleanup();
+      process.exit(0);
+    });
+
+    // Handle uncaught exceptions (last resort cleanup)
+    process.once('uncaughtException', (err) => {
+      console.error('[pinocchio-ws] Uncaught exception:', err);
+      cleanup();
+      process.exit(1);
+    });
+
+    // Handle process.exit() calls
+    process.once('exit', cleanup);
   }
 
   /**
@@ -482,12 +546,30 @@ export class PinocchioWebSocket {
       this.wss = null;
     }
 
-    // Close HTTP server
+    // Close HTTP server (TCP)
     if (this.httpServer) {
       await new Promise<void>((resolve) => {
         this.httpServer!.close(() => resolve());
       });
       this.httpServer = null;
+    }
+
+    // Issue #44: Close Unix socket server and clean up socket file
+    if (this.unixServer) {
+      await new Promise<void>((resolve) => {
+        this.unixServer!.close(() => resolve());
+      });
+      this.unixServer = null;
+    }
+
+    // Clean up socket file
+    if (this.config.unixSocket && existsSync(this.config.unixSocket)) {
+      try {
+        unlinkSync(this.config.unixSocket);
+        console.error(`[pinocchio-ws] Cleaned up socket file: ${this.config.unixSocket}`);
+      } catch (err) {
+        // Ignore errors during cleanup
+      }
     }
 
     console.error('[pinocchio-ws] WebSocket server closed');

--- a/src/websocket/server.ts
+++ b/src/websocket/server.ts
@@ -7,7 +7,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
 import { createServer as createHttpsServer } from 'https';
 import { createConnection } from 'net';
-import { unlinkSync, existsSync, promises as fs } from 'fs';
+import { unlinkSync, existsSync, mkdirSync, promises as fs } from 'fs';
 import { timingSafeEqual } from 'crypto';
 import * as path from 'path';
 import * as os from 'os';
@@ -153,6 +153,9 @@ export class PinocchioWebSocket {
         );
         unlinkSync(this.config.unixSocket);
       }
+
+      // Create parent directory for socket file if it doesn't exist
+      mkdirSync(path.dirname(this.config.unixSocket), { recursive: true });
 
       // Create Unix socket server with HTTP handler
       this.unixServer = createServer((req, res) => {

--- a/src/websocket/types.ts
+++ b/src/websocket/types.ts
@@ -30,7 +30,8 @@ export const DEFAULT_WEBSOCKET_CONFIG: WebSocketConfig = {
   subscriptionPolicy: 'open',
   bufferSize: 1000,
   // Issue #44: Use UDS by default to avoid port conflicts
-  unixSocket: process.env.PINOCCHIO_SOCKET_PATH || `/tmp/pinocchio-${process.pid}.sock`,
+  // Issue #96: Fixed path so nested agents can find the socket via shared volume
+  unixSocket: process.env.PINOCCHIO_SOCKET_PATH || '/tmp/pinocchio/mcp.sock',
 };
 
 // ============================================================================

--- a/src/websocket/types.ts
+++ b/src/websocket/types.ts
@@ -24,11 +24,13 @@ export interface WebSocketConfig {
 
 export const DEFAULT_WEBSOCKET_CONFIG: WebSocketConfig = {
   enabled: true,
-  port: 3001,
+  port: 3001,  // Only used if unixSocket is not set
   bindAddress: '127.0.0.1',
   auth: 'none',
   subscriptionPolicy: 'open',
   bufferSize: 1000,
+  // Issue #44: Use UDS by default to avoid port conflicts
+  unixSocket: process.env.PINOCCHIO_SOCKET_PATH || `/tmp/pinocchio-${process.pid}.sock`,
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Replaces TCP WebSocket (port 3001) with Unix Domain Socket
- Socket path: `/tmp/pinocchio-{PID}.sock` (configurable via `PINOCCHIO_SOCKET_PATH` env var)
- Automatically cleans up stale socket files from crashed processes
- Fixes Issue #44: stale containers can no longer block reconnection

## Changes
- **`src/websocket/types.ts`**: Updated `DEFAULT_WEBSOCKET_CONFIG` to use UDS by default
- **`src/websocket/server.ts`**: 
  - Made UDS the primary listening mode (TCP is now fallback)
  - Added socket file cleanup on startup for crashed processes
  - Added cleanup handlers for SIGINT, SIGTERM, uncaughtException, and process.exit
  - Updated `close()` method to clean up Unix socket server
- **`docker-compose.yml`**: Removed port 3001 mapping (no longer needed)
- **`run-mcp.sh`**: Removed `--service-ports` flag (no TCP port to expose)
- **`src/index.ts`**: Updated default config and startup logging

## Root Cause
When Claude Code exits abruptly, the Docker container's `--rm` flag may not trigger, leaving zombie containers that hold port 3001. New MCP server instances then fail with "port already allocated".

## Solution
Unix Domain Sockets use file paths instead of ports. Benefits:
- **No port conflicts**: Each process uses `/tmp/pinocchio-{PID}.sock`
- **Automatic cleanup**: Socket files are cleaned on startup (stale) and shutdown
- **Faster**: UDS is faster than TCP (no network stack overhead)

## Test Plan
- [ ] Start MCP server, verify socket file created at `/tmp/pinocchio-{PID}.sock`
- [ ] Kill MCP server abruptly (SIGKILL), restart - should work without manual cleanup
- [ ] Verify WebSocket connections work over UDS
- [ ] Verify HTTP endpoints (`/health`, `/api/v1/spawn`) work over UDS

Closes #44